### PR TITLE
#195 Refactor: 와인 검색 isLiked 조회 최적화

### DIFF
--- a/src/main/java/com/drinkeg/drinkeg/dto/WineDTO/response/SearchWineResponseDTO.java
+++ b/src/main/java/com/drinkeg/drinkeg/dto/WineDTO/response/SearchWineResponseDTO.java
@@ -1,10 +1,10 @@
 package com.drinkeg.drinkeg.dto.WineDTO.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 
 @Getter
 @Builder
-@AllArgsConstructor
 @NoArgsConstructor
 public class SearchWineResponseDTO {
 
@@ -20,5 +20,18 @@ public class SearchWineResponseDTO {
     private int price;
 
     private boolean isLiked;
+
+    @QueryProjection // 생성자에 추가
+    public SearchWineResponseDTO(Long wineId, String name, String imageUrl, String sort, String area,
+                                 float satisfaction, int price, boolean isLiked) {
+        this.wineId = wineId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.sort = sort;
+        this.area = area;
+        this.satisfaction = satisfaction;
+        this.price = price;
+        this.isLiked = isLiked;
+    }
 
 }

--- a/src/main/java/com/drinkeg/drinkeg/repository/WineRepository.java
+++ b/src/main/java/com/drinkeg/drinkeg/repository/WineRepository.java
@@ -10,9 +10,6 @@ import java.util.Optional;
 
 public interface WineRepository extends JpaRepository<Wine, Long>, WineRepositoryCustom{
 
-    // 검색한 와인 이름이 포함된 모든 와인을 찾는다.
-    List<Wine> findAllByNameContainingIgnoreCaseOrderByName(String name);
-
     // 추천 와인 조회를 위한 쿼리
     List<Wine> findAllBySortContainingIgnoreCase(String sort);
     List<Wine> findAllByAreaContainingIgnoreCase(String area);

--- a/src/main/java/com/drinkeg/drinkeg/repository/WineRepositoryCustom.java
+++ b/src/main/java/com/drinkeg/drinkeg/repository/WineRepositoryCustom.java
@@ -1,5 +1,6 @@
 package com.drinkeg.drinkeg.repository;
 
+import com.drinkeg.drinkeg.dto.WineDTO.response.SearchWineResponseDTO;
 import com.drinkeg.drinkeg.dto.WineDTO.response.WineResponseDTO;
 import com.drinkeg.drinkeg.dto.WineDTO.response.WineReviewResponseDTO;
 
@@ -9,4 +10,8 @@ public interface WineRepositoryCustom {
     List<WineReviewResponseDTO> findWineReviewsById(Long wineId);
 
     WineResponseDTO findWineResponseByWineId(Long wineId);
+
+    List<SearchWineResponseDTO> findWinesWithLikeStatus(String searchName, Long memberId);
+
+
 }

--- a/src/main/java/com/drinkeg/drinkeg/repository/WineRepositoryImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/repository/WineRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.drinkeg.drinkeg.repository;
 
+import com.drinkeg.drinkeg.dto.WineDTO.response.QSearchWineResponseDTO;
+import com.drinkeg.drinkeg.dto.WineDTO.response.SearchWineResponseDTO;
 import com.drinkeg.drinkeg.dto.WineDTO.response.WineResponseDTO;
 import com.drinkeg.drinkeg.dto.WineDTO.response.WineReviewResponseDTO;
 import com.querydsl.core.types.Projections;
@@ -13,6 +15,7 @@ import java.util.List;
 
 import static com.drinkeg.drinkeg.domain.QTastingNote.tastingNote;
 import static com.drinkeg.drinkeg.domain.QWine.wine;
+import static com.drinkeg.drinkeg.domain.QWineWishlist.wineWishlist;
 
 @Repository
 @RequiredArgsConstructor
@@ -59,5 +62,26 @@ public class WineRepositoryImpl implements WineRepositoryCustom{
                 .leftJoin(wine.wineNote)
                 .where(wine.id.eq(wineId))
                 .fetchOne();
+    }
+
+    @Override
+    public List<SearchWineResponseDTO> findWinesWithLikeStatus(String searchName, Long memberId) {
+        return queryFactory
+                .select(new QSearchWineResponseDTO(
+                        wine.id,
+                        wine.name,
+                        wine.imageUrl,
+                        wine.sort,
+                        wine.area,
+                        wine.satisfaction,
+                        wine.price,
+                        wineWishlist.id.isNotNull() // memberId와 wineId에 따라 isLiked 여부
+                ))
+                .from(wine)
+                .leftJoin(wineWishlist)
+                .on(wineWishlist.wine.eq(wine).and(wineWishlist.member.id.eq(memberId)))
+                .where(wine.name.containsIgnoreCase(searchName))
+                .orderBy(wine.name.asc())
+                .fetch();
     }
 }

--- a/src/main/java/com/drinkeg/drinkeg/service/wineService/WineServiceImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/service/wineService/WineServiceImpl.java
@@ -39,19 +39,13 @@ public class WineServiceImpl implements WineService {
     @Override
     public List<SearchWineResponseDTO> searchWinesByName(String searchName, PrincipalDetail principalDetail) {
 
+        long startTime = System.currentTimeMillis();
         // 회원을 조회한다.
         Member member = memberService.loadMemberByPrincipalDetail(principalDetail);
 
-
         // 검색한 와인 이름이 포함된 모든 와인을 찾는다 (LIKE '%검색어%').
-        List<Wine> foundWines = wineRepository.findAllByNameContainingIgnoreCaseOrderByName(searchName);
-
-        // 와인을 NoteWineResponseDTO로 변환한다.
-        return foundWines.stream()
-                .map(wine -> WineConverter.toSearchWineResponseDTO(wine,
-                        wineWishlistService.isLiked(member, wine))
-                )
-                .collect(Collectors.toList());
+        // 이때 memberId를 이용해 isLiked()를 같이 조회한다
+        return wineRepository.findWinesWithLikeStatus(searchName, member.getId());
     }
 
     @Override

--- a/src/main/java/com/drinkeg/drinkeg/service/wineService/WineServiceImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/service/wineService/WineServiceImpl.java
@@ -39,7 +39,6 @@ public class WineServiceImpl implements WineService {
     @Override
     public List<SearchWineResponseDTO> searchWinesByName(String searchName, PrincipalDetail principalDetail) {
 
-        long startTime = System.currentTimeMillis();
         // 회원을 조회한다.
         Member member = memberService.loadMemberByPrincipalDetail(principalDetail);
 


### PR DESCRIPTION
- 기존 조회한 와인들을 대상으로 각각의 isLiked() 확인 쿼리를 날려 성능이 좋지 않았음
- 기존 800(알파벳 하나 검색 시) ~ 6000ms(단어 하나 검색 시) 까지 검색 시간이 오래걸림

- QueryDSL 을 통해 wine을 조회하면서 isLiked()까지 같이 조회하게 변경
- 검색어가 길든 짧은 약 130ms의 일관된 검색 시간 확인