### PR TITLE
#218 Refactor: TastingNote 전체 조회 시 member 조인 삭제

### DIFF
--- a/src/main/java/com/drinkeg/drinkeg/tastingNote/repository/TastingNoteRepositoryImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/tastingNote/repository/TastingNoteRepositoryImpl.java
@@ -9,7 +9,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
-import static com.drinkeg.drinkeg.domain.QMember.member;
 import static com.drinkeg.drinkeg.tastingNote.domain.QTastingNote.tastingNote;
 import static com.drinkeg.drinkeg.tastingNote.domain.QTastingNoteNose.tastingNoteNose;
 import static com.drinkeg.drinkeg.wine.domain.QWine.wine;
@@ -44,10 +43,9 @@ public class TastingNoteRepositoryImpl implements TastingNoteRepositoryCustom{
     @Override
     public List<TastingNote> findTastingNotesWithWineAndNoseByUsername(String username) {
         return queryFactory.selectFrom(tastingNote)
-                .leftJoin(tastingNote.member, member).fetchJoin()
                 .leftJoin(tastingNote.wine, wine).fetchJoin()
                 .leftJoin(tastingNote.noseList, tastingNoteNose).fetchJoin()
-                .where(member.username.eq(username))
+                .where(tastingNote.member.username.eq(username))
                 .fetch();
     }
 }


### PR DESCRIPTION
- 기존 member 를 leftJoin 하여 같이 불러왔는데 굳이 member의 정보는 필요 없다고 판단하여 join 하지 않고 "where(tastingNote.member.username.eq(username))" 하는 식으로 join없이 찾을 수 있게 수정