### PR TITLE
Refactor/152

### DIFF
--- a/src/main/java/com/drinkeg/drinkeg/domain/member/controller/MemberController.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/controller/MemberController.java
@@ -1,15 +1,11 @@
 package com.drinkeg.drinkeg.domain.member.controller;
 
 import com.drinkeg.drinkeg.domain.member.dto.*;
-import com.drinkeg.drinkeg.domain.member.dto.loginDTO.NameCheckResponse;
 import com.drinkeg.drinkeg.global.apipayLoad.ApiResponse;
 import com.drinkeg.drinkeg.global.security.jwt.TokenService;
 import com.drinkeg.drinkeg.domain.member.dto.loginDTO.commonDTO.PrincipalDetail;
 import com.drinkeg.drinkeg.domain.member.service.JoinService;
 import com.drinkeg.drinkeg.domain.member.service.MemberService;
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
@@ -47,9 +43,9 @@ public class MemberController {
 
     @PatchMapping("/member")
     @Operation(summary = "사용자 초기 정보 추가", description = "첫 로그인 여부에 따라 isFirst 속성이 true인 경우 사용자 초기 정보를 추가합니다.")
-    public ApiResponse<?> addMemberDetail(@RequestPart(value = "multipartFile", required = false) MultipartFile multipartFile,  @RequestPart("memberRequest")  MemberRequestDTO memberRequestDTO, @AuthenticationPrincipal PrincipalDetail principalDetail) {
+    public ApiResponse<String> addMemberDetail(@RequestBody MemberRequest memberRequest, @AuthenticationPrincipal PrincipalDetail principalDetail) {
 
-        MemberResponseDTO memberResponseDTO = joinService.addMemberDetail(memberRequestDTO, principalDetail.getUsername(),multipartFile);
+        joinService.addMemberDetail(memberRequest, principalDetail.getUsername());
         return ApiResponse.onSuccess("사용자 초기 정보 추가 완료");
     }
 
@@ -67,7 +63,7 @@ public class MemberController {
 
     @PatchMapping("/member/info")
     @Operation(summary = "마이페이지 정보 수정 ", description = "마이페이지의 정보를 수정합니다.")
-    public ApiResponse<?> updateMemberInfo(@AuthenticationPrincipal PrincipalDetail principalDetail, @RequestBody MemberUpdateRequest memberUpdateRequest){
+    public ApiResponse<String> updateMemberInfo(@AuthenticationPrincipal PrincipalDetail principalDetail, @RequestBody MemberUpdateRequest memberUpdateRequest){
 
         memberService.updateMemberInfo(memberUpdateRequest, principalDetail.getUsername());
         return ApiResponse.onSuccess("정보 수정 성공");

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/controller/MemberController.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -30,7 +31,7 @@ public class MemberController {
 
     @PostMapping("/join")
     @Operation(summary = "회원가입", description = "username과 password를 입력받아 회원가입을 진행합니다.")
-    public ApiResponse<?> joinProcess(@RequestBody JoinRequest joinRequest) {
+    public ApiResponse<?> joinProcess(@Valid @RequestBody JoinRequest joinRequest) {
 
         joinService.join(joinRequest);
         return ApiResponse.onSuccess("회원가입 성공");
@@ -60,7 +61,7 @@ public class MemberController {
 
     @PostMapping("/member/{nickname}")
     @Operation(summary = "마이페이지내에 닉네임 중복 검사 ", description = "중복된 닉네임이면 False, 사용 가능한 닉네임이면 True를 반환합니다.")
-    public ApiResponse<NameCheckResponse> checkNickname(@AuthenticationPrincipal PrincipalDetail principalDetail, @PathVariable String nickname){
+    public ApiResponse<Boolean> checkNickname(@AuthenticationPrincipal PrincipalDetail principalDetail, @PathVariable String nickname){
         return ApiResponse.onSuccess(memberService.isNicknameAvailable(nickname));
     }
 
@@ -74,9 +75,8 @@ public class MemberController {
 
     @PostMapping("/join/check")
     @Operation(summary = "이메일 중복 검사", description = "이메일(username) 중복 여부를 반환합니다.")
-    public ApiResponse<UsernameCheckResponse> checkUsername(@RequestBody UsernameCheckRequest usernameCheckRequest) {
-        UsernameCheckResponse usernameCheckResponse = joinService.isDuplicatedUsername(usernameCheckRequest);
-        return ApiResponse.onSuccess(usernameCheckResponse);
+    public ApiResponse<Boolean> checkUsername(@RequestBody UsernameCheckRequest usernameCheckRequest) {
+        return ApiResponse.onSuccess(joinService.isDuplicatedUsername(usernameCheckRequest));
     }
 
     @PostMapping(value = "/member/profileImage", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/domain/Member.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.drinkeg.drinkeg.domain.member.domain;
 
 
 import com.drinkeg.drinkeg.domain.member.converter.StringListConverter;
+import com.drinkeg.drinkeg.domain.member.dto.MemberRequest;
 import com.drinkeg.drinkeg.domain.member.dto.MemberUpdateRequest;
 import com.drinkeg.drinkeg.domain.myWine.domain.MyWine;
 import com.drinkeg.drinkeg.domain.member.enums.Provider;
@@ -16,7 +17,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
@@ -132,16 +132,14 @@ public class Member {
     }
 
 
-    public void updateFirstUser(String name, Boolean isNewbie, Long monthPrice,
-                                List<String> wineSort, List<String> wineArea,List<String> wineVariety, String region, String profileUrl){
-        if(name != null) this.name = name;
-        if(isNewbie != null) this.isNewbie = isNewbie;
-        if(monthPrice != null) this.monthPriceMax = monthPrice;
-        if(wineSort != null) this.wineSort = wineSort;
-        if(wineArea != null) this.wineArea = wineArea;
-        if(wineVariety != null) this.wineVariety = wineVariety;
-        if(region != null) this.region = region;
-        if(profileUrl != null) this.imageUrl = profileUrl;
+    public void updateFirstUser(MemberRequest memberRequest){
+        if(memberRequest.getName() != null) this.name = memberRequest.getName();
+        if(memberRequest.getIsNewbie() != null) this.isNewbie = memberRequest.getIsNewbie();
+        if(memberRequest.getMonthPrice() != null) this.monthPriceMax = memberRequest.getMonthPrice();
+        if(memberRequest.getWineSort() != null) this.wineSort = memberRequest.getWineSort();
+        if(memberRequest.getWineArea() != null) this.wineArea = memberRequest.getWineArea();
+        if(memberRequest.getWineVariety() != null) this.wineVariety = memberRequest.getWineVariety();
+        if(memberRequest.getRegion() != null) this.region =memberRequest.getRegion();
         this.isFirst = false;
     }
 }

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/dto/JoinRequest.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/dto/JoinRequest.java
@@ -1,18 +1,28 @@
 package com.drinkeg.drinkeg.domain.member.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
-import java.time.LocalDate;
-import java.util.List;
 
 @Getter
 @Builder
 public class JoinRequest {
 
+
+    @NotBlank(message = "Username은 필수입니다.")
     private String username;
+
+    @NotBlank(message = "Password는 필수입니다.")
+    @Pattern(
+            regexp = "^(?=.*[A-Za-z])(?=.*\\d)[A-Za-z\\d]+$",
+            message = "Password는 최소 하나의 영문자와 숫자를 포함해야 합니다."
+    )
     private String password;
+
+    @NotBlank(message = "rePassword는 필수입니다.")
     private String rePassword;
 
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/dto/MemberInfoResponse.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/dto/MemberInfoResponse.java
@@ -20,7 +20,7 @@ public class MemberInfoResponse {
     private String authType;
     private boolean isAdult;
 
-    public static MemberInfoResponse create(Member member){
+    public static MemberInfoResponse of(Member member){
 
         return  MemberInfoResponse.builder()
                 .imageUrl(member.getImageUrl())

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/dto/MemberRequest.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/dto/MemberRequest.java
@@ -12,7 +12,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberRequestDTO {
+public class MemberRequest {
 
     private String name;
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/dto/MemberResponseDTO.java
@@ -34,7 +34,7 @@ public class MemberResponseDTO {
 
     private String imageUrl;
 
-    public static MemberResponseDTO create(Member member){
+    public static MemberResponseDTO of(Member member){
 
         return  MemberResponseDTO.builder()
                 .id(member.getId())

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/dto/UsernameCheckResponse.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/dto/UsernameCheckResponse.java
@@ -1,6 +1,0 @@
-package com.drinkeg.drinkeg.domain.member.dto;
-
-public record UsernameCheckResponse(
-        boolean isDuplicate
-) {
-}

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/login/oauth2/apple/appleService/AppleLoginService.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/login/oauth2/apple/appleService/AppleLoginService.java
@@ -74,7 +74,7 @@ public class AppleLoginService {
 
         }
 
-        return LoginResponseDTO.create(member.getId(), member.getUsername(), member.getRole(),member.getIsFirst() );
+        return LoginResponseDTO.of(member.getId(), member.getUsername(), member.getRole(),member.getIsFirst() );
     }
 
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/login/oauth2/dto/LoginResponseDTO.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/login/oauth2/dto/LoginResponseDTO.java
@@ -23,7 +23,7 @@ public class LoginResponseDTO {
     private Boolean isFirst;
     // private String refreshToken
 
-    public static LoginResponseDTO create(Long id, String username, Role role,Boolean isFirst){
+    public static LoginResponseDTO of(Long id, String username, Role role,Boolean isFirst){
         return LoginResponseDTO.builder()
                 .id(id)
                 .username(username)

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/login/oauth2/kakao/kakaoService/KakaoLoginService.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/login/oauth2/kakao/kakaoService/KakaoLoginService.java
@@ -63,7 +63,7 @@ public class KakaoLoginService {
 
         memberRepository.save(member);
 
-        return LoginResponseDTO.create(member.getId(), member.getUsername(), member.getRole(),member.getIsFirst());
+        return LoginResponseDTO.of(member.getId(), member.getUsername(), member.getRole(),member.getIsFirst());
 
     }
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/service/JoinService.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/service/JoinService.java
@@ -49,9 +49,6 @@ public class JoinService {
         // 회원이 입력한 정보로 update 하고 isFirst = false 로 변경
         member.updateFirstUser(memberRequest);
 
-        memberRepository.save(member);
-
-
         return MemberResponseDTO.of(member);
     }
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/service/JoinService.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/service/JoinService.java
@@ -15,6 +15,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class JoinService {
 
     private final MemberRepository memberRepository;
@@ -22,7 +23,7 @@ public class JoinService {
     private final StorageService storageService;
 
 
-    @Transactional
+
     public void join(JoinRequest joinRequest) {
 
         String username = joinRequest.getUsername();
@@ -35,14 +36,11 @@ public class JoinService {
         if (!password.equals(rePassword)){
             throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
         }
-        if(!isValidPassword(password)){
-            throw new GeneralException(ErrorStatus.PASSWORD_NOT_INVALID);
-        }
+
 
         Member member = Member.createMember( username,(bCryptPasswordEncoder.encode(password) ),true);
 
         memberRepository.save(member);
-        System.out.println("Saved Member: " );
 
     }
 
@@ -65,24 +63,13 @@ public class JoinService {
         memberRepository.save(member);
 
 
-        return MemberResponseDTO.create(member);
+        return MemberResponseDTO.of(member);
     }
 
-    public boolean isValidPassword(String password) {
 
-        // 영문자, 숫자, 특수문자 각각에 대한 패턴
-        String letterPattern = ".*[A-Za-z].*";
-        String digitPattern = ".*\\d.*";
+    @Transactional(readOnly = true)
+    public boolean isDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
 
-        boolean hasLetter = password.matches(letterPattern);
-        boolean hasDigit = password.matches(digitPattern);
-
-        // 세 가지 조건이 모두 충족되는지 확인
-        return hasLetter && hasDigit;
-    }
-
-    public UsernameCheckResponse isDuplicatedUsername(UsernameCheckRequest usernameCheckRequest) {
-
-        return new UsernameCheckResponse(memberRepository.existsByUsername(usernameCheckRequest.username()));
+        return memberRepository.existsByUsername(usernameCheckRequest.username());
     }
 }

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/service/JoinService.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/service/JoinService.java
@@ -5,13 +5,11 @@ import com.drinkeg.drinkeg.global.apipayLoad.code.status.ErrorStatus;
 import com.drinkeg.drinkeg.domain.member.domain.Member;
 import com.drinkeg.drinkeg.domain.member.repostitory.MemberRepository;
 import com.drinkeg.drinkeg.global.exception.GeneralException;
-import com.drinkeg.drinkeg.infra.storage.StoragePathName;
 import com.drinkeg.drinkeg.infra.storage.StorageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -37,28 +35,19 @@ public class JoinService {
             throw new GeneralException(ErrorStatus.PASSWORD_NOT_MATCH);
         }
 
-
         Member member = Member.createMember( username,(bCryptPasswordEncoder.encode(password) ),true);
-
         memberRepository.save(member);
 
     }
 
-    public MemberResponseDTO addMemberDetail(MemberRequestDTO memberRequestDTO, String username, MultipartFile multipartFile) {
+    public MemberResponseDTO addMemberDetail(MemberRequest memberRequest, String username) {
 
         Member member = memberRepository.findByUsername(username)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.SESSION_UNAUTHORIZED));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        String profileImage = null;
-
-        if (multipartFile != null ) {
-            profileImage = storageService.uploadFile(multipartFile, StoragePathName.MEMBER_PROFILE);
-        }
 
         // 회원이 입력한 정보로 update 하고 isFirst = false 로 변경
-        member.updateFirstUser(memberRequestDTO.getName(), memberRequestDTO.getIsNewbie(), memberRequestDTO.getMonthPrice(),
-                memberRequestDTO.getWineSort(), memberRequestDTO.getWineArea(), memberRequestDTO.getWineVariety(),memberRequestDTO.getRegion(),
-                profileImage);
+        member.updateFirstUser(memberRequest);
 
         memberRepository.save(member);
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/service/MemberService.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/service/MemberService.java
@@ -14,7 +14,7 @@ public interface MemberService {
 
     public MemberInfoResponse showMemberInfo(String username);
 
-    public NameCheckResponse isNicknameAvailable(String nickname);
+    public boolean isNicknameAvailable(String nickname);
 
     public void updateMemberInfo(MemberUpdateRequest memberUpdateRequest, String username);
 

--- a/src/main/java/com/drinkeg/drinkeg/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/member/service/MemberServiceImpl.java
@@ -48,12 +48,12 @@ public class MemberServiceImpl implements MemberService {
     public MemberInfoResponse showMemberInfo(String username){
         Member member = memberRepository.findByUsername(username)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        return MemberInfoResponse.create(member);
+        return MemberInfoResponse.of(member);
     }
 
     @Override
-    public NameCheckResponse isNicknameAvailable(String nickname){
-        return NameCheckResponse.create(!memberRepository.existsByName(nickname));
+    public boolean isNicknameAvailable(String nickname){
+        return !memberRepository.existsByName(nickname);
     }
 
     @Override

--- a/src/main/java/com/drinkeg/drinkeg/global/security/jwt/LoginFilter.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/security/jwt/LoginFilter.java
@@ -58,7 +58,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
             jwtExceptionHandler(response, ErrorStatus.PASSWORD_NOT_FUND);
             return null;
         }
-        String username = "drinkeg "+ requestBody.get("username");
+        String username = requestBody.get("username");
         String password = requestBody.get("password");
 
         // 스프링 시큐리티에서 username과 password를 검증하기 위해서는 token에 담아야 함
@@ -101,7 +101,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         Boolean isFirst = principalDetail.getIsFirst();
 
 
-        LoginResponseDTO loginResponseDTO = LoginResponseDTO.create(id,username,Role.fromValue(role),isFirst);
+        LoginResponseDTO loginResponseDTO = LoginResponseDTO.of(id,username,Role.fromValue(role),isFirst);
 
 
         // ApiResponse 생성

--- a/src/test/java/com/drinkeg/drinkeg/domain/member/service/JoinServiceTest.java
+++ b/src/test/java/com/drinkeg/drinkeg/domain/member/service/JoinServiceTest.java
@@ -69,17 +69,6 @@ public class JoinServiceTest extends IntegrationTestSupport {
                 .hasMessageContaining(ErrorStatus.PASSWORD_NOT_MATCH.getMessage());
     }
 
-    @Test
-    @DisplayName("비밀번호가 유효하지 않을 경우 예외를 반환한다.")
-    void joinMember_InvalidPassword() {
-        // Given
-        JoinRequest joinRequest = createJoinRequest("itsme", "short", "short"); // 예: 너무 짧은 비밀번호
-
-        // When & Then
-        assertThatThrownBy(() -> joinService.join(joinRequest))
-                .isInstanceOf(GeneralException.class)
-                .hasMessageContaining(ErrorStatus.PASSWORD_NOT_INVALID.getMessage());
-    }
     private JoinRequest createJoinRequest(String username, String password, String rePassword){
         return JoinRequest.builder()
                 .username(username)

--- a/src/test/java/com/drinkeg/drinkeg/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/com/drinkeg/drinkeg/domain/member/service/MemberServiceTest.java
@@ -101,38 +101,6 @@ public class MemberServiceTest extends IntegrationTestSupport {
                         null                );
     }
 
-    @Test
-    @DisplayName("존재하는 memberId로 멤버를 조회한다.")
-    void getMemberById_Success() {
-        // Given
-        Member member1 = memberRepository.save(createMember("user1", "윤다영", "55azaz@naver.com", "서울", "Drinkeg", true," https://drinkeg-bucket-1.s3.ap-northeast-2.amazonaws.com/member/profile/70af4bd2-717c-48d8-93d5-1a563de091a2"));
-
-        // When
-        Member foundMember = memberService.getMemberById(member1.getId());
-
-        // Then
-        assertThat(foundMember).isNotNull();
-        assertThat(foundMember.getUsername()).isEqualTo("user1");
-        assertThat(foundMember.getName()).isEqualTo("윤다영");
-        assertThat(foundMember.getEmail()).isEqualTo("55azaz@naver.com");
-        assertThat(foundMember.getRegion()).isEqualTo("서울");
-        assertThat(foundMember.getProvider().getValue()).isEqualTo("Drinkeg");
-        assertThat(foundMember.isAdult()).isTrue();
-        assertThat(foundMember.getImageUrl()).isNull();
-    }
-
-    @Test
-    @DisplayName("존재하지 않는 memberId로 조회 시 GeneralException 발생")
-    void getMemberById_Failure_MemberNotFound() {
-        // Given
-        Long nonExistentId = 999L;
-
-        // When & Then
-        assertThatThrownBy(() -> memberService.getMemberById(nonExistentId))
-                .isInstanceOf(GeneralException.class)
-                .hasMessageContaining(ErrorStatus.MEMBER_NOT_FOUND.getMessage());
-    }
-
 
 
     private Member createMember(


### PR DESCRIPTION
1. 회원가입 기능
    - JoinDTO → joinRequest로 변경 (파일 이름 통일)
    - joinRequset에 Validation 설정 join Service 내에 비밀번호 유효성 검증 로직 삭제 후 @pattern으로 처리
    - joinService 전체에 Transactional 설정 (회원 조회만 하는 isDuplicatedUsername 에는 readOnly 설정)
    - Member 엔티티에 AllArgsConstructor 제거 (id 값 같은 거 바꾸지 않기 위해)
    - join 시에는 save() 없애지 않음 (새로운 엔티티 생성이기 때문에)

2. 마이페이지 조회 기능
    - DTO 변환 메서드 명 of로 통일하기

3. 마이페이지 닉네임 중복 검사 기능, 이메일 중복 검사 기능 
    - DTO말고 바로 boolean으로 반환

4 취향 찾기 기능
- member 엔티티 update고 Transactional 사용했기 때문에 save() 메소드 삭제

