### PR TITLE
#401 Refactor: Content-Type 에러 핸들링 추가

### DIFF
--- a/src/main/java/com/drinkeg/drinkeg/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/exception/ExceptionAdvice.java
@@ -3,6 +3,7 @@ package com.drinkeg.drinkeg.global.exception;
 import com.drinkeg.drinkeg.global.apipayLoad.ApiResponse;
 import com.drinkeg.drinkeg.global.apipayLoad.code.ReasonDTO;
 import jakarta.servlet.http.HttpServletRequest;
+import org.apache.tomcat.util.http.fileupload.impl.InvalidContentTypeException;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
@@ -30,6 +31,18 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 .build();
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorReason);
+    }
+
+    @ExceptionHandler(InvalidContentTypeException.class)
+    public ResponseEntity<?> handleInvalidContentTypeException(InvalidContentTypeException e, HttpServletRequest request) {
+        ReasonDTO errorReason = ReasonDTO.builder()
+                .isSuccess(false)
+                .httpStatus(HttpStatus.BAD_REQUEST)
+                .message("요청의 Content-Type이 올바르지 않습니다. multipart/form-data 형식이어야 합니다.")
+                .code("INVALID_CONTENT_TYPE")
+                .build();
+
+        return handleExceptionInternal(e, errorReason, null, request);
     }
 
     @ExceptionHandler(value = GeneralException.class)


### PR DESCRIPTION
## 🌱 관련 이슈
close #{401}

## 📌 작업 내용 및 특이사항
Content-Type 에러 핸들링 추가
{
    "isSuccess": false,
    "httpStatus": "BAD_REQUEST",
    "code": "INVALID_CONTENT_TYPE",
    "message": "요청의 Content-Type이 올바르지 않습니다. multipart/form-data 형식이어야 합니다."
}


## 📝 참고사항

## 📚 기타
