### PR TITLE
#415 Refactor: 와인 검색 시 공백 및 쉼표 제거

### DIFF
--- a/src/main/java/com/drinkeg/drinkeg/domain/wine/repository/WineRepositoryImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/wine/repository/WineRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.drinkeg.drinkeg.domain.wine.domain.Wine;
 import com.drinkeg.drinkeg.domain.wine.dto.response.WinePreviewResponse;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,13 +38,17 @@ public class WineRepositoryImpl implements WineRepositoryCustom {
     public List<Wine> searchByName(String searchName, Pageable pageable) {
         return queryFactory.selectFrom(wine)
                 .where(
-                        wine.name.containsIgnoreCase(searchName)
-                                .or(wine.nameEng.containsIgnoreCase(searchName))
+                        removeSpecialChars(wine.name).containsIgnoreCase(searchName)
+                                .or(removeSpecialChars(wine.nameEng).containsIgnoreCase(searchName))
                 )
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .orderBy(wine.name.asc())
                 .fetch();
+    }
+
+    private StringExpression removeSpecialChars(StringExpression column) {
+        return Expressions.stringTemplate("REPLACE(REPLACE({0}, ',', ''), ' ', '')", column);
     }
 
     @Override

--- a/src/main/java/com/drinkeg/drinkeg/domain/wine/service/WineServiceImpl.java
+++ b/src/main/java/com/drinkeg/drinkeg/domain/wine/service/WineServiceImpl.java
@@ -34,7 +34,7 @@ public class WineServiceImpl implements WineService {
     @Override
     public PageResponse<WinePreviewResponse> searchWinesByName(String searchName, Pageable pageable) {
 
-        List<WinePreviewResponse> winePreviewList = wineRepository.searchByName(searchName, pageable)
+        List<WinePreviewResponse> winePreviewList = wineRepository.searchByName(searchName.replace(" ", ""), pageable)
                 .stream()
                 .map(WinePreviewResponse::of)
                 .toList();


### PR DESCRIPTION
## 🌱 관련 이슈
close #{415}

## 📌 작업 내용 및 특이사항
- 와인 검색 시 공백 및 쉼표 제거
- 사용자가 입력한 검색어에서는 공백만 제거
- 와인 데이터에서는 공백과 쉼표 모두 제거

## 📝 참고사항

## 📚 기타
추후 ElasticSearch 도입 예정
