### PR TITLE
#455 chore: CI/CD 워크플로우 분리

### DIFF
--- a/.github/workflows/drinkig-cd.yml
+++ b/.github/workflows/drinkig-cd.yml
@@ -1,15 +1,11 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
 # Repo Action 페이지에 나타날 이름
-name: Spring Boot & Gradle CI/CD
+name: Spring Boot & Gradle CD
 
 # Event Trigger
-# dev branch에 push 또는 pull request가 발생할 경우 동작
-# branch 단위 외에도, tag나 cron 식 등을 사용할 수 있음
+# master branch에 push가 발생할 경우 동작
 on:
   push:
-    branches: [ dev ]
+    branches: [ master ]
 
 jobs:
   build:

--- a/.github/workflows/drinkig-ci.yml
+++ b/.github/workflows/drinkig-ci.yml
@@ -1,0 +1,40 @@
+# Repo Action 페이지에 나타날 이름
+name: Spring Boot & Gradle CI
+
+# Event Trigger
+# dev branch에 pull request가 발생할 경우 동작
+on:
+  pull_request:
+    branches: [ dev ]
+
+jobs:
+  build:
+    # 실행 환경 지정
+    runs-on: ubuntu-24.04
+
+    # Task의 sequence를 명시한다.
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
+        ## create application.yaml
+      - name: make application.yml
+        run: |
+          ## create application.yml
+          mkdir ./src/main/resources
+          cd ./src/main/resources
+          # application.yml 파일 생성
+          touch ./application.yml
+          # GitHub-Actions 에서 설정한 값을 application.yaml 파일에 쓰기
+          echo "${{ secrets.APPLICATION }}" >> ./application.yml
+        shell: bash
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # Build
+      - name: Build with Gradle
+        run: ./gradlew clean build -x test


### PR DESCRIPTION
## 🌱 관련 이슈
close #{455}

## 📌 작업 내용 및 특이사항
- dev 브랜치에 pull request가 생성되면 CI, master 브랜치에 push가 일어나면 CD가 이뤄지도록 워크플로우를 분리했습니다.

## 📝 참고사항
- 현재 324 중 16 테스트가 실패해서 일단 CI 워크플로우에도 테스트 없이 빌드하도록 설정했습니다.
- 실패한 테스트 확인해보고 바꿔야할듯!

## 📚 기타
