### PR TITLE
chore: 모니터링 환경 구축

### DIFF
--- a/.github/workflows/drinkig-ci.yml
+++ b/.github/workflows/drinkig-ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: make application.yml
         run: |
           ## create application.yml
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           # application.yml 파일 생성
           touch ./application.yml

--- a/.github/workflows/drinkig-dev-cd.yml
+++ b/.github/workflows/drinkig-dev-cd.yml
@@ -21,7 +21,7 @@ jobs:
       - name: make application.yml
         run: |
           ## create application.yml
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           # application.yml 파일 생성
           touch ./application.yml

--- a/.github/workflows/drinkig-prod-cd.yml
+++ b/.github/workflows/drinkig-prod-cd.yml
@@ -21,7 +21,7 @@ jobs:
       - name: make application.yml
         run: |
           ## create application.yml
-          mkdir ./src/main/resources
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           # application.yml 파일 생성
           touch ./application.yml

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
@@ -53,16 +55,13 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
-
 	implementation 'org.bouncycastle:bcpkix-jdk15on:1.69'
 	implementation 'org.bouncycastle:bcprov-jdk15on:1.69'
-
 
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
-
 
 	//swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
@@ -82,7 +81,14 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"		// 어노테이션 프로세서 설정
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"	// 어노테이션 프로세서 설정
 
-	implementation 'com.opencsv:opencsv:5.7.1'  // OpenCSV 의존성 추가
+	// OpenCSV
+	implementation 'com.opencsv:opencsv:5.7.1'
+
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// Loki
+	implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
 }
 
 // gradle clean 시에 QClass 디렉토리 삭제

--- a/src/main/java/com/drinkeg/drinkeg/global/config/SecurityConfig.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.drinkeg.drinkeg.global.config;
 
+import com.drinkeg.drinkeg.global.logging.filter.HttpLoggingFilter;
 import com.drinkeg.drinkeg.global.security.jwt.*;
 import com.drinkeg.drinkeg.infra.redis.RedisClient;
 import jakarta.servlet.http.HttpServletRequest;
@@ -104,6 +105,8 @@ public class SecurityConfig {
         //HTTP Basic 인증 방식 disable
         http
                 .httpBasic((auth) -> auth.disable());
+
+        http.addFilterBefore(new HttpLoggingFilter(), UsernamePasswordAuthenticationFilter.class);
 
         //JWT 필터 추가
         http

--- a/src/main/java/com/drinkeg/drinkeg/global/config/SecurityConfig.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/config/SecurityConfig.java
@@ -44,7 +44,9 @@ public class SecurityConfig {
         return web -> {
             web.ignoring()
                     .requestMatchers("/join/**","/login/apple/**","/login/kakao/**",
-                            "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**","/clientSecret","/check-environment","reissue");// 필터를 타면 안되는 경로
+                            "/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**",
+                            "/clientSecret","/check-environment","reissue",
+                            "/actuator/**");// 필터를 타면 안되는 경로
         };
     }
 
@@ -125,6 +127,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorize) -> authorize
                         .requestMatchers("/api-docs/**", "/swagger-ui/**", "/swagger-ui.html/**", "/v3/api-docs/**", "/swagger-ui/index.html#/**").permitAll()
                         .requestMatchers("/", "/join/**", "/login", "/reissue","/login/apple","/login/kakao","/clientSecret","/check-environment","reissue").permitAll()
+                        .requestMatchers("/actuator/**").permitAll()
 
                         .requestMatchers(HttpMethod.GET,"/home").hasRole("USER")
                         .requestMatchers("/wine/**").hasRole("USER")

--- a/src/main/java/com/drinkeg/drinkeg/global/logging/dto/HttpRequestLogInfo.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/logging/dto/HttpRequestLogInfo.java
@@ -1,0 +1,35 @@
+package com.drinkeg.drinkeg.global.logging.dto;
+
+import com.drinkeg.drinkeg.global.logging.filter.wrapper.RequestWrapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.MDC;
+
+public record HttpRequestLogInfo(
+        String traceId,
+        String requestMethod,
+        String requestUri,
+        String xAmznTraceId,
+        String userAgent) {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static HttpRequestLogInfo from(RequestWrapper requestWrapper) {
+        String queryString = requestWrapper.getQueryString();
+        String traceId = MDC.get("traceId");
+        String requestMethod = requestWrapper.getMethod();
+        String requestUri =
+                requestWrapper.getRequestURI() + (queryString == null ? "" : "?" + queryString);
+        String xAmznTraceId = requestWrapper.getHeader("x-amzn-trace-id");
+        String userAgent = requestWrapper.getHeader("user-agent");
+
+        return new HttpRequestLogInfo(traceId, requestMethod, requestUri, xAmznTraceId, userAgent);
+    }
+
+    public String toString() {
+        try {
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/drinkeg/drinkeg/global/logging/dto/HttpResponseLogInfo.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/logging/dto/HttpResponseLogInfo.java
@@ -1,0 +1,72 @@
+package com.drinkeg.drinkeg.global.logging.dto;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.MDC;
+import org.springframework.http.MediaType;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
+
+public record HttpResponseLogInfo(String traceId, Object responseBody, Integer responseStatus) {
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static HttpResponseLogInfo from(ContentCachingResponseWrapper response)
+            throws IOException {
+        String traceId = MDC.get("traceId");
+        String rawBody = getContent(response.getContentType(), response.getContentInputStream());
+        Integer responseStatus = response.getStatus();
+
+        Object parsedBody;
+        try {
+            parsedBody = objectMapper.readValue(rawBody, Object.class);
+        } catch (Exception e) {
+            parsedBody = rawBody;
+        }
+
+        return new HttpResponseLogInfo(traceId, parsedBody, responseStatus);
+    }
+
+    private static String getContent(String contentType, InputStream inputStream)
+            throws IOException {
+        boolean visible =
+                isVisible(
+                        MediaType.valueOf(contentType == null ? "application/json" : contentType));
+        if (visible) {
+            byte[] content = StreamUtils.copyToByteArray(inputStream);
+            if (content.length > 0) {
+                return new String(content, 0, Math.min(content.length, 5120));
+            } else {
+                return "";
+            }
+        } else {
+            return "BINARY";
+        }
+    }
+
+    private static boolean isVisible(MediaType mediaType) {
+        final List<MediaType> VISIBLE_TYPES =
+                Arrays.asList(
+                        MediaType.valueOf("text/*"),
+                        MediaType.APPLICATION_FORM_URLENCODED,
+                        MediaType.APPLICATION_JSON,
+                        MediaType.APPLICATION_XML,
+                        MediaType.valueOf("application/*+json"),
+                        MediaType.valueOf("application/*+xml"),
+                        MediaType.MULTIPART_FORM_DATA);
+
+        return VISIBLE_TYPES.stream().anyMatch(visibleType -> visibleType.includes(mediaType));
+    }
+
+    public String toString() {
+        try {
+            return objectMapper.writeValueAsString(this);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/drinkeg/drinkeg/global/logging/filter/HttpLoggingFilter.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/logging/filter/HttpLoggingFilter.java
@@ -1,0 +1,74 @@
+package com.drinkeg.drinkeg.global.logging.filter;
+
+import com.drinkeg.drinkeg.global.logging.dto.HttpRequestLogInfo;
+import com.drinkeg.drinkeg.global.logging.dto.HttpResponseLogInfo;
+import com.drinkeg.drinkeg.global.logging.filter.wrapper.RequestWrapper;
+import com.drinkeg.drinkeg.global.logging.filter.wrapper.ResponseWrapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import static org.springframework.web.multipart.support.MultipartResolutionDelegate.isMultipartRequest;
+
+@Slf4j
+public class HttpLoggingFilter extends OncePerRequestFilter {
+
+    @Override
+    protected boolean shouldNotFilterAsyncDispatch() {
+        return true;
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        MDC.put("traceId", UUID.randomUUID().toString());
+
+        String uri = request.getRequestURI();
+        if (uri.startsWith("/actuator/")) {
+            filterChain.doFilter(request, response);
+            MDC.clear();
+            return;
+        }
+
+        if (isAsyncDispatch(request)) {
+            filterChain.doFilter(request, response);
+        } else if (isMultipartRequest(request)) {
+            filterChain.doFilter(request, response);
+        } else {
+            doFilterWrapped(
+                    new RequestWrapper(request), new ResponseWrapper(response), filterChain);
+        }
+        MDC.clear();
+    }
+
+    protected void doFilterWrapped(
+            RequestWrapper request, ContentCachingResponseWrapper response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            logRequest(request);
+            filterChain.doFilter(request, response);
+        } finally {
+            logResponse(response);
+            response.copyBodyToResponse();
+        }
+    }
+
+    private static void logRequest(RequestWrapper request) {
+        HttpRequestLogInfo httpLogInfo = HttpRequestLogInfo.from(request);
+        log.info(httpLogInfo.toString());
+    }
+
+    private static void logResponse(ContentCachingResponseWrapper response) throws IOException {
+        HttpResponseLogInfo httpLogInfo = HttpResponseLogInfo.from(response);
+        log.info(httpLogInfo.toString());
+    }
+}

--- a/src/main/java/com/drinkeg/drinkeg/global/logging/filter/wrapper/RequestWrapper.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/logging/filter/wrapper/RequestWrapper.java
@@ -1,0 +1,55 @@
+package com.drinkeg.drinkeg.global.logging.filter.wrapper;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import org.springframework.util.StreamUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class RequestWrapper extends HttpServletRequestWrapper {
+
+    private final byte[] cachedInputStream;
+
+    public RequestWrapper(HttpServletRequest request) throws IOException {
+        super(request);
+        InputStream requestInputStream = request.getInputStream();
+        this.cachedInputStream = StreamUtils.copyToByteArray(requestInputStream);
+    }
+
+    @Override
+    public ServletInputStream getInputStream() {
+        return new ServletInputStream() {
+            private final InputStream cachedBodyInputStream =
+                    new ByteArrayInputStream(cachedInputStream);
+
+            @Override
+            public boolean isFinished() {
+                try {
+                    return cachedBodyInputStream.available() == 0;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                return false;
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setReadListener(ReadListener listener) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public int read() throws IOException {
+                return cachedBodyInputStream.read();
+            }
+        };
+    }
+}

--- a/src/main/java/com/drinkeg/drinkeg/global/logging/filter/wrapper/ResponseWrapper.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/logging/filter/wrapper/ResponseWrapper.java
@@ -1,0 +1,10 @@
+package com.drinkeg.drinkeg.global.logging.filter.wrapper;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+public class ResponseWrapper extends ContentCachingResponseWrapper {
+    public ResponseWrapper(HttpServletResponse response) {
+        super(response);
+    }
+}

--- a/src/main/java/com/drinkeg/drinkeg/global/security/jwt/CustomUserDetailsService.java
+++ b/src/main/java/com/drinkeg/drinkeg/global/security/jwt/CustomUserDetailsService.java
@@ -21,17 +21,11 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-
-        Optional<Member> existData = memberRepository.findByUsername(username);
-        Member userData = existData.get();
-
-        UserDTO userDTO = UserDTO.create(userData);
-
-        if (userDTO != null) {
-
-            return new PrincipalDetail(userDTO);
-        }
-
-        return null;
+        return memberRepository.findByUsername(username)
+                .map(userData -> {
+                    UserDTO userDTO = UserDTO.create(userData);
+                    return new PrincipalDetail(userDTO);
+                })
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
     }
 }

--- a/src/main/java/com/drinkeg/drinkeg/infra/monitoring/docker-compose-monitoring.yml
+++ b/src/main/java/com/drinkeg/drinkeg/infra/monitoring/docker-compose-monitoring.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    networks:
+      - drinkig_monitoring_network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    volumes:
+      - grafana-storage:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - drinkig_monitoring_network
+
+  loki:
+    image: grafana/loki:latest
+    container_name: loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/local-config.yml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yml
+    networks:
+      - drinkig_monitoring_network
+
+volumes:
+  grafana-storage:
+  loki-data:
+
+networks:
+  drinkig_monitoring_network:
+    external: true

--- a/src/main/java/com/drinkeg/drinkeg/infra/monitoring/loki/loki-config.yml
+++ b/src/main/java/com/drinkeg/drinkeg/infra/monitoring/loki/loki-config.yml
@@ -1,0 +1,40 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+# table_manager:
+#   retention_deletes_enabled: true
+#   retention_period: 336h # 14일

--- a/src/main/java/com/drinkeg/drinkeg/infra/monitoring/prometheus/prometheus.yml
+++ b/src/main/java/com/drinkeg/drinkeg/infra/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,24 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'drinkig-prod'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['drinkig_prod:8080']
+        labels:
+          env: prod
+
+  - job_name: 'drinkig-dev'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['drinkig_dev:8081']
+        labels:
+          env: dev
+
+  - job_name: 'drinkig-local'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        labels:
+          env: local

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="LOKI_URL" source="logging.loki.url"/>
+    <springProperty scope="context" name="APP_ENV" source="app.env"/>
+
+    <!-- Loki 동기 Appender -->
+    <appender name="LOKI_SYNC" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_URL}</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=drinkig,service=backend,env=${APP_ENV},level=%level</pattern>
+            </label>
+            <message>
+                <pattern>%msg%n</pattern>
+            </message>
+        </format>
+    </appender>
+
+    <!-- 비동기 Loki Appender -->
+    <appender name="LOKI" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="LOKI_SYNC"/>
+        <queueSize>512</queueSize>
+        <discardingThreshold>0</discardingThreshold>
+        <neverBlock>true</neverBlock> <!-- 큐가 꽉 차도 메인 스레드를 막지 않음 -->
+    </appender>
+
+    <!-- 콘솔 로그 Appender -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg %X{traceId}%n</pattern>
+        </encoder>
+    </appender>
+
+    <!-- 루트 로그 설정 -->
+    <root level="INFO">
+        <appender-ref ref="LOKI"/>
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## 🌱 관련 이슈
close #475

---

## 📌 작업 내용 및 특이사항
### 모니터링 환경 구축 (Prometheus + Grafana + Loki)
- Spring Boot 애플리케이션의 로그 및 메트릭을 수집/시각화하기 위한 모니터링 환경을 Docker 기반으로 구축
- 요청/응답 로그는 Loki를 통해 수집하고, 메트릭은 Prometheus를 통해 수집하여 Grafana에서 통합적으로 확인

### 📁 구성 파일 설명
#### 1. docker-compose-monitoring.yml
- Prometheus, Grafana, Loki를 Docker로 실행
- **prometheus**: `/actuator/prometheus`에서 메트릭 수집
- **grafana**: Loki 및 Prometheus 시각화
- **loki**: 구조화된 로그 수집
- **공통 네트워크** `drinkig_monitoring_network`로 Spring 컨테이너와 연결
  - ```docker network create drinkig_monitoring_network``` 명령어를 통해 미리 네트워크 생성 후 실행 필요

#### 2. prometheus.yml
- scrape_interval: 메트릭 수집 주기 (15초)
- 컨테이너 또는 호스트 주소를 지정해 메트릭 수집
- 로컬에서 인텔리제이를 이용해 스프링을 실행하면 ```host.docker.internal:8080``` 타겟 사용

#### 3. loki-config.yml
- 파일시스템 기반 로그 저장
- 하루 단위 인덱스
- 7일 이상 된 로그가 새로 들어오면 수집 거부

#### 4. logback-spring.xml
- 콘솔과 Loki 모두로 로그 전송
- traceId를 통한 요청 추적 가능
- AsyncAppender 설정으로 성능 저하 방지

---
### HTTP 요청/응답 로깅 필터 구현 및 traceId 기반 통합 로깅 적용
- HTTP 요청과 응답의 상세 내용을 JSON 포맷으로 로그에 기록하는 HttpLoggingFilter 구현
- 각 요청에 대해 고유한 traceId 생성 및 MDC에 저장하여 로그 추적 용이성 향상
- 요청 본문을 캐싱하는 RequestWrapper와 응답 본문을 캐싱하는 ResponseWrapper 적용
- 로그 기록 시 멀티파트 요청, actuator 엔드포인트, 비동기 디스패치 등 예외 상황 처리
- 요청/응답 로그를 HttpRequestLogInfo, HttpResponseLogInfo DTO로 관리하며, 바디 크기 제한(최대 5KB) 적용
- Loki, Grafana 등 모니터링 도구와 연동 가능하도록 JSON 형태 로그 포맷과 MDC 활용
- traceId를 포함해 여러 로그가 쉽게 연관되어 문제 디버깅 및 분석 지원

#### 1. HttpLoggingFilter (로깅 필터)
 ```
- OncePerRequestFilter 상속하여 커스텀 필터 구현 
- 요청당 한 번만 실행되도록 shouldNotFilterAsyncDispatch() 오버라이드하여 비동기 재실행 방지
- doFilterInternal()에서 다음 처리:
  - 요청 URI가 /actuator/로 시작하면 필터 동작 건너뜀 (모니터링 엔드포인트 제외)
  - 비동기 디스패치 및 멀티파트 요청도 필터 로깅 대상에서 제외
  - 그 외 요청에 대해 RequestWrapper와 ResponseWrapper를 사용하여 본문 캐싱 후 로깅 수행
  - MDC에 UUID 기반 traceId 생성 후 할당, 필터 종료 시 MDC 정리하여 메모리 누수 방지
```

#### 2. RequestWrapper (요청 본문 캐싱)
 ```
 - HttpServletRequestWrapper 상속
 - 요청의 InputStream을 바이트 배열로 미리 복사해 둠으로써, 여러 번 읽을 수 있도록 지원
 - getInputStream() 메서드 재정의하여 복사된 바이트 배열로부터 스트림 반환
 - 본문을 여러 번 읽는 로깅 시나리오에서 InputStream 소모 문제 해결
 ```

#### 3. ResponseWrapper (응답 본문 캐싱)
 ```
 - ContentCachingResponseWrapper를 상속하여 응답 내용을 캐싱
 - 필터 종료 시 캐싱된 응답 바이트를 실제 응답 스트림에 다시 복사하여 클라이언트에 전달
 - 응답 로그 기록 시 바디를 안전하게 읽을 수 있도록 지원
 ```

#### 4. HttpRequestLogInfo & HttpResponseLogInfo (로그 DTO)
 ```
 - 요청 및 응답 로그 정보를 객체로 추상화하여 JSON 직렬화 가능
 - 요청 로그에는 traceId, HTTP 메서드, URI, 쿼리, AWS X-Amzn-Trace-Id, User-Agent 정보 포함
 - 응답 로그에는 traceId, HTTP 상태 코드, 응답 바디(최대 5KB) 포함
 - 응답 바디는 Content-Type 기준으로 텍스트, JSON 등 읽을 수 있는 타입만 출력하며, 바이너리는 “BINARY”로 표기
 - JSON 포맷으로 로그를 찍어 Loki 같은 중앙 집중식 로그 수집시스템에 적합하게 설계
 ```
---

- Grafana에서 Loki 연결 후 로그 확인
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/63c3af92-532d-4355-82b1-57176db04bd7" />

- 인텔리제이 내 콘솔 로그 확인
<img width="1331" alt="image" src="https://github.com/user-attachments/assets/e43ef6e1-1dd5-4218-a5d1-7c6845906418" />

---

## 📝 참고사항

## 📚 기타
